### PR TITLE
Detection fixes

### DIFF
--- a/smil.check.js
+++ b/smil.check.js
@@ -95,7 +95,14 @@ try{
 		}
 
 	}
+	
+	//check from Modernizr. Added because this was not working properly in IE11
+	var supported = !!document.createElementNS &&
+		/SVGAnimate/.test((({}).toString).call(document.createElementNS('http://www.w3.org/2000/svg', 'animate')));
 
+	if(!supported) {
+		throw "FakeSmile required due to: animate";
+	}
 }catch(exp){
 
 	// debug only - uncomment these lines to know which particular element and/or cause is triggering FakeSmile to load

--- a/smil.check.js
+++ b/smil.check.js
@@ -137,7 +137,7 @@ try{
 		scriptEle.setAttributeNS(xlinkns, "xlink:href", relPath + "smil.user.js");
 	}else{
 		var scriptEle = document.createElement("script");
-		scriptEle.setAttribute(src, relPath + "smil.user.js");
+		scriptEle.setAttribute("src", relPath + "smil.user.js");
 	}
 	scriptEle.setAttribute("type", currScript.getAttribute("type"));
 	document.documentElement.appendChild(scriptEle);


### PR DESCRIPTION
I found some issues with the detection.
- IE11 was not detected correctly (did not try in other IE versions). IE11 only partially supports SMIL. Modernizr reports that IE does not support SMIL. I added the Modernizr detection logic to smil.check.js  so that IE11 would trigger loading of smil.user.js.
- setAttribute() was called with missing src reference instead of "src" string.
